### PR TITLE
Fix missing export for creation scoring

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -2,7 +2,7 @@ import { kingdom, turnData } from "./state.js";
 import { Validators } from "./utils.js";
 import { KINGDOM_GOVERNMENTS } from "./constants.js";
 import { renderSpecific, showEditLeaderModal, addSettlement, showEditLotModal, deleteSettlement, showArmyModal, deleteArmy } from "./rendering.js";
-import { clearTurn, saveTurn, handleResourceRoll, handlePayConsumption, handleApplyUpkeepEffects, handleEventCheck } from "./turn.js";
+import { clearTurn, saveTurn, handleResourceRoll, handlePayConsumption, handleApplyUpkeepEffects, handleEventCheck, calculateAndRenderCreationScores, updateSkillInvestmentDropdowns } from "./turn.js";
 
 // EVENT HANDLERS & LISTENERS
 // ==========================================

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 import { kingdom, turnData, history, saveState, loadState } from "./state.js";
-import { renderAll, debouncedRenderAll, initEventListeners, calculateAndRenderCreationScores } from "./rendering.js";
-import { clearTurn } from "./turn.js";
+import { renderAll, debouncedRenderAll, initEventListeners } from "./rendering.js";
+import { clearTurn, calculateAndRenderCreationScores } from "./turn.js";
 import { DATA_VERSION } from "./constants.js";
 
 // ==========================================


### PR DESCRIPTION
## Summary
- import `calculateAndRenderCreationScores` from `turn.js`
- re-export and update event handlers for kingdom creation logic

## Testing
- `node --check js/main.js`
- `node --check js/events.js`


------
https://chatgpt.com/codex/tasks/task_e_6873c8c6dd0c832fa31c6086631cbf11