### PR TITLE
Fix missing import for safeOperation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,7 @@ import { renderAll, debouncedRenderAll } from "./rendering.js";
 import { initEventListeners } from "./events.js";
 import { clearTurn, calculateAndRenderCreationScores } from "./turn.js";
 import { DATA_VERSION } from "./constants.js";
+import { safeOperation } from "./utils.js";
 
 // ==========================================
 


### PR DESCRIPTION
## Summary
- add missing `safeOperation` import in main.js

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873caeeb018832f90f366ec646a162a