### PR TITLE
Fix missing import for KINGDOM_SKILLS

### DIFF
--- a/js/rendering.js
+++ b/js/rendering.js
@@ -1,5 +1,5 @@
 import { kingdom, turnData, history, A11yHelpers } from "./state.js";
-import { availableStructures, structureColors, KINGDOM_GOVERNMENTS, KINGDOM_CHARTERS, KINGDOM_HEARTLANDS, KINGDOM_FEATS, PROFICIENCY_RANKS, KINGDOM_SIZE_TABLE } from "./constants.js";
+import { availableStructures, structureColors, KINGDOM_GOVERNMENTS, KINGDOM_CHARTERS, KINGDOM_HEARTLANDS, KINGDOM_FEATS, PROFICIENCY_RANKS, KINGDOM_SIZE_TABLE, KINGDOM_SKILLS } from "./constants.js";
 import { calculateStructureBonuses, calculateSkillModifiers, calculateControlDC, isSettlementOvercrowded } from "./calculations.js";
 import { Validators, handleValidatedInput, debounce } from "./utils.js";
 


### PR DESCRIPTION
## Summary
- import `KINGDOM_SKILLS` in rendering module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873cbbb4c5c832fa254bc36ae950870