### PR TITLE
Fix missing import for calculateConsumption

### DIFF
--- a/js/rendering.js
+++ b/js/rendering.js
@@ -1,6 +1,6 @@
 import { kingdom, turnData, history, A11yHelpers } from "./state.js";
 import { availableStructures, structureColors, KINGDOM_GOVERNMENTS, KINGDOM_CHARTERS, KINGDOM_HEARTLANDS, KINGDOM_FEATS, PROFICIENCY_RANKS, KINGDOM_SIZE_TABLE, KINGDOM_SKILLS } from "./constants.js";
-import { calculateStructureBonuses, calculateSkillModifiers, calculateControlDC, isSettlementOvercrowded } from "./calculations.js";
+import { calculateStructureBonuses, calculateSkillModifiers, calculateControlDC, calculateConsumption, isSettlementOvercrowded } from "./calculations.js";
 import { Validators, handleValidatedInput, debounce } from "./utils.js";
 
 // ==========================================


### PR DESCRIPTION
## Summary
- import `calculateConsumption` in `rendering.js`

## Testing
- `grep -n "calculateConsumption" -n js/rendering.js`

------
https://chatgpt.com/codex/tasks/task_e_6873ccabe7f0832fa99f15d21ec7cb47