### PR TITLE
Fix missing import for turn tracker

### DIFF
--- a/js/turn.js
+++ b/js/turn.js
@@ -1,7 +1,7 @@
 import { kingdom, turnData, history, A11yHelpers, setTurnData } from "./state.js";
 import { KINGDOM_ACTIVITIES, KINGDOM_SIZE_TABLE, RANDOM_KINGDOM_EVENTS } from "./constants.js";
 import { calculateConsumption, updateRuin } from "./calculations.js";
-import { showConfirmationModal } from "./rendering.js";
+import { showConfirmationModal, renderTurnTracker } from "./rendering.js";
 
 // ==========================================
 // KINGDOM CREATION LOGIC


### PR DESCRIPTION
## Summary
- fix `renderTurnTracker` reference by importing it in `turn.js`

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6873d0a7ced0832f8f0652d8a1041981