### PR TITLE
Update imports to support save features

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -1,7 +1,7 @@
-import { kingdom, turnData } from "./state.js";
-import { Validators } from "./utils.js";
+import { kingdom, turnData, saveState, resetKingdom, exportState, importState, recoverFromBackup } from "./state.js";
+import { Validators, handleValidatedInput } from "./utils.js";
 import { KINGDOM_GOVERNMENTS } from "./constants.js";
-import { renderSpecific, showEditLeaderModal, addSettlement, showEditLotModal, deleteSettlement, showArmyModal, deleteArmy } from "./rendering.js";
+import { renderSpecific, showEditLeaderModal, addSettlement, showEditLotModal, deleteSettlement, showArmyModal, deleteArmy, showLevelUpModal } from "./rendering.js";
 import { clearTurn, saveTurn, handleResourceRoll, handlePayConsumption, handleApplyUpkeepEffects, handleEventCheck, calculateAndRenderCreationScores, updateSkillInvestmentDropdowns } from "./turn.js";
 
 // EVENT HANDLERS & LISTENERS

--- a/js/rendering.js
+++ b/js/rendering.js
@@ -1,4 +1,4 @@
-import { kingdom, turnData, history, A11yHelpers } from "./state.js";
+import { kingdom, turnData, history, A11yHelpers, saveState } from "./state.js";
 import { availableStructures, structureColors, KINGDOM_GOVERNMENTS, KINGDOM_CHARTERS, KINGDOM_HEARTLANDS, KINGDOM_FEATS, PROFICIENCY_RANKS, KINGDOM_SIZE_TABLE, KINGDOM_SKILLS, KINGDOM_ACTIVITIES } from "./constants.js";
 import { calculateStructureBonuses, calculateSkillModifiers, calculateControlDC, calculateConsumption, isSettlementOvercrowded } from "./calculations.js";
 import { Validators, handleValidatedInput, debounce } from "./utils.js";

--- a/js/state.js
+++ b/js/state.js
@@ -1,6 +1,6 @@
 import { LOCAL_STORAGE_KEY, DATA_VERSION, defaultKingdomData, KINGDOM_SKILLS } from "./constants.js";
 import { safeOperation } from "./utils.js";
-import { renderAll } from "./rendering.js";
+import { renderAll, showConfirmationModal } from "./rendering.js";
 import { clearTurn } from "./turn.js";
 
 // ==========================================

--- a/js/turn.js
+++ b/js/turn.js
@@ -1,7 +1,7 @@
-import { kingdom, turnData, history, A11yHelpers, setTurnData } from "./state.js";
+import { kingdom, turnData, history, A11yHelpers, setTurnData, saveState } from "./state.js";
 import { KINGDOM_ACTIVITIES, KINGDOM_SIZE_TABLE, RANDOM_KINGDOM_EVENTS } from "./constants.js";
 import { calculateConsumption, updateRuin } from "./calculations.js";
-import { showConfirmationModal, renderTurnTracker } from "./rendering.js";
+import { showConfirmationModal, renderTurnTracker, renderAll } from "./rendering.js";
 
 // ==========================================
 // KINGDOM CREATION LOGIC


### PR DESCRIPTION
## Summary
- sync import lists across modules
- include save/load helpers in events.js
- bring saveState into rendering
- expose saveState and renderAll to turn.js
- use showConfirmationModal in state.js

## Testing
- `node --check js/events.js`
- `node --check js/rendering.js`
- `node --check js/turn.js`
- `node --check js/state.js`

------
https://chatgpt.com/codex/tasks/task_e_6873d36b0678832fa8afd30fe5865310