### PR TITLE
Fix missing constants in turn module

### DIFF
--- a/js/turn.js
+++ b/js/turn.js
@@ -1,5 +1,13 @@
 import { kingdom, turnData, history, A11yHelpers, setTurnData, saveState } from "./state.js";
-import { KINGDOM_ACTIVITIES, KINGDOM_SIZE_TABLE, RANDOM_KINGDOM_EVENTS } from "./constants.js";
+import {
+  KINGDOM_ACTIVITIES,
+  KINGDOM_SIZE_TABLE,
+  RANDOM_KINGDOM_EVENTS,
+  KINGDOM_CHARTERS,
+  KINGDOM_HEARTLANDS,
+  KINGDOM_GOVERNMENTS,
+  KINGDOM_SKILLS,
+} from "./constants.js";
 import { calculateConsumption, updateRuin } from "./calculations.js";
 import { showConfirmationModal, renderTurnTracker, renderAll } from "./rendering.js";
 


### PR DESCRIPTION
## Summary
- import kingdom creation constants in `turn.js`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6873d7bc0008832f8ee1aff05f92afa8